### PR TITLE
fix(sendReaction): allow empty reaction to remove and validate single emoji

### DIFF
--- a/nodes/EvolutionApi/execute/messages/sendReaction.ts
+++ b/nodes/EvolutionApi/execute/messages/sendReaction.ts
@@ -13,23 +13,22 @@ export async function sendReaction(ef: IExecuteFunctions) {
 		const remoteJid = ef.getNodeParameter('remoteJid', 0) as string;
 		const messageId = ef.getNodeParameter('messageId', 0) as string;
 		const fromMe = ef.getNodeParameter('fromMe', 0) as boolean;
-		const reaction = ef.getNodeParameter('reaction', 0) as string;
 
-		// Reaction validation
-		if (!reaction) {
-			const errorData = {
-				success: false,
-				error: {
-					message: 'Invalid reaction',
-					details: 'You must provide an emoji for the reaction',
-					code: 'INVALID_REACTION',
-					timestamp: new Date().toISOString(),
-				},
-			};
-			return {
-				json: errorData,
-				error: errorData,
-			};
+
+		// Reaction validation (allow empty string to remove reaction)
+		let reaction = ef.getNodeParameter('reaction', 0, '') as string;
+
+		// allow empty string
+		if (reaction === undefined || reaction === null) {
+			reaction = '';
+		}
+
+		// validate single emoji or empty
+		if (reaction !== '' && [...reaction].length !== 1) {
+			throw new NodeOperationError(
+				ef.getNode(),
+				'Reaction must be a single emoji or empty string'
+			);
 		}
 
 		const body: any = {

--- a/nodes/EvolutionApi/execute/messages/sendReaction.ts
+++ b/nodes/EvolutionApi/execute/messages/sendReaction.ts
@@ -25,10 +25,20 @@ export async function sendReaction(ef: IExecuteFunctions) {
 
 		// validate single emoji or empty
 		if (reaction !== '' && [...reaction].length !== 1) {
-			throw new NodeOperationError(
-				ef.getNode(),
-				'Reaction must be a single emoji or empty string'
-			);
+			const errorData = {
+				success: false,
+				error: {
+					message: 'Invalid reaction',
+					details: 'You must provide an emoji for the reaction',
+					code: 'INVALID_REACTION',
+					timestamp: new Date().toISOString(),
+				},
+			};
+
+			return {
+				json: errorData,
+				error: errorData,
+			};
 		}
 
 		const body: any = {

--- a/nodes/EvolutionApi/properties/messages.fields.ts
+++ b/nodes/EvolutionApi/properties/messages.fields.ts
@@ -1820,8 +1820,8 @@ export const messagesFields: INodeProperties[] = [
 		name: 'reaction',
 		type: 'string',
 		default: '👍',
-		required: true,
-		description: 'Emoji to be used as a reaction',
+		required: false,
+		description: 'Emoji to be used as a reaction (empty to remove reaction)',
 		displayOptions: {
 			show: {
 				resource: ['messages-api'],


### PR DESCRIPTION
This pull request updates the reaction handling for messages, enabling users to remove a reaction by submitting an empty string and improving validation. The changes also clarify the reaction parameter's usage in the node properties.

Reaction handling improvements:

* Updated `sendReaction` in `sendReaction.ts` to allow an empty string for the `reaction` parameter, enabling removal of a reaction. Also, improved validation to ensure only a single emoji or empty string is accepted.
* Modified error handling to return error data when validation fails in `sendReaction.ts`.

Parameter configuration updates:

* Changed the `reaction` field in `messages.fields.ts` to be optional (`required: false`) and updated the description to indicate that an empty value removes the reaction.